### PR TITLE
fix compiler warnings when compiled with -std=

### DIFF
--- a/chainif.c
+++ b/chainif.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <errno.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -8,8 +9,6 @@
 #include <spawn.h>
 #include <sys/wait.h>
 #include <unistd.h>
-
-extern char *const *const environ;
 
 static char **
 getblock(char *args[const])
@@ -27,7 +26,7 @@ getblock(char *args[const])
 }
 
 static void
-usage()
+usage(void)
 {
     static char const message[] =
         "Usage: chainif [-AEn] { condition... } { chain... } cmd...\n";

--- a/creatememfd.c
+++ b/creatememfd.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #define _GNU_SOURCE /* memfd_create, MFD_ALLOW_SEALING */
 #include <errno.h>
 #include <limits.h>
@@ -8,7 +9,7 @@
 #include <unistd.h>
 
 static void
-usage()
+usage(void)
 {
     static char const message[] =
         "Usage: creatememfd [-S] fd name cmd [args]...\n";

--- a/fdcmp.c
+++ b/fdcmp.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <errno.h>
 #include <limits.h>
 #include <stdbool.h>
@@ -29,7 +30,7 @@ str2posint(int *const intp, char const str[const],
 }
 
 static void
-usage()
+usage(void)
 {
     static char const message[] =
         "Usage: fdcmp [-0123en] [-p PID1] [-P PID2] fd1 fd2 [cmd]...\n";

--- a/fdseal.c
+++ b/fdseal.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #define _GNU_SOURCE /* F_ADD_SEALS, F_GET_SEALS, F_SEAL_* */
 #include <errno.h>
 #include <limits.h>
@@ -24,7 +25,7 @@ static struct sealinfo {
 };
 
 static void
-usage()
+usage(void)
 {
     static char const message[] =
         "Usage: fdseal add [-s SEAL]... FD [CMD]...\n"

--- a/fdtruncate.c
+++ b/fdtruncate.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <errno.h>
 #include <limits.h>
 #include <stdbool.h>
@@ -7,7 +8,7 @@
 #include <unistd.h>
 
 static void
-usage()
+usage(void)
 {
     static char const um[] = "Usage: fdtruncate fd [length] [cmd]...\n";
     if (fputs(um, stderr) == EOF)

--- a/openpathfd.c
+++ b/openpathfd.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #define _GNU_SOURCE /* O_PATH */
 #include <errno.h>
 #include <limits.h>
@@ -9,7 +10,7 @@
 #include <unistd.h>
 
 static void
-usage()
+usage(void)
 {
     static char const message[] =
         "Usage: openpathfd [-dL] fd file cmd [args]...\n";

--- a/openpidfd.c
+++ b/openpidfd.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
@@ -8,7 +9,7 @@
 #include <unistd.h>
 
 static void
-usage()
+usage(void)
 {
     static char const msg[] = "Usage: openpidfd fd pid cmd [args]...\n";
     if (fputs(msg, stderr) == EOF)

--- a/pidfdgetfd.c
+++ b/pidfdgetfd.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
@@ -8,7 +9,7 @@
 #include <unistd.h>
 
 static void
-usage()
+usage(void)
 {
     static char const message[] =
         "Usage: pidfdgetfd pidfd targetfd fd cmd [args]...\n";

--- a/pollinfd.c
+++ b/pollinfd.c
@@ -1,14 +1,15 @@
+#define _GNU_SOURCE
 #include <errno.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <unistd.h>
 
 static void
-usage()
+usage(void)
 {
     static char const message[] =
         "Usage: pollinfd [-t timeout] fd [cmd] [args]...\n";

--- a/psendfd.c
+++ b/psendfd.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <errno.h>
 #include <limits.h>
 #include <stdbool.h>
@@ -15,7 +16,7 @@
 #include <unistd.h>
 
 static void
-usage()
+usage(void)
 {
     static char const msg[] =
         "Usage: psendfd [-ef] [-m mintargetfd] [-P sourcepid] pid fd "

--- a/secretmemfd.c
+++ b/secretmemfd.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
@@ -7,7 +8,7 @@
 #include <unistd.h>
 
 static void
-usage()
+usage(void)
 {
     static char const msg[] = "Usage: secretmemfd fd cmd [args]...\n";
     if (fputs(msg, stderr) == EOF)


### PR DESCRIPTION
Fixes compiler warning on both glibc (related to `getopt`) and musl (related to `environ`).